### PR TITLE
pass optional arguments to scrcpy

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -8,4 +8,4 @@ export ADB="${APPDIR}/usr/bin/adb"
 export SCRCPY_SERVER_PATH="${APPDIR}/usr/local/share/scrcpy/scrcpy-server"
 export PATH="${APPDIR}/usr/bin:${PATH}"
 export LD_LIBRARY_PATH="${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
-${APPDIR}/usr/bin/scrcpy
+${APPDIR}/usr/bin/scrcpy "$@"


### PR DESCRIPTION
In its current state, no arguments were passed to `scrcpy`, so arguments such as `--turn-screen-off` etc. were not working.